### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/commands/etkdg.py
+++ b/commands/etkdg.py
@@ -38,9 +38,9 @@ def generate(opts):
     m = Chem.AddHs(m)
     AllChem.EmbedMolecule(m, AllChem.ETKDG())
 
-    if opts['ff'] is 'UFF':
+    if opts['ff'] == 'UFF':
         AllChem.UFFOptimizeMolecule(m)
-    elif opts['ff'] is 'MMFF94':
+    elif opts['ff'] == 'MMFF94':
         AllChem.MMFFOptimizeMolecule(m)
 
     return Chem.MolToMolBlock(m)


### PR DESCRIPTION
These can be cases where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.

$ `python3`
```
>>> uff = 'UF'
>>> uff += 'F'
>>> uff == 'UFF'
True
>>> uff is 'UFF'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
False
```

$ `flake8 . --count --select=E9,F63,F7 --show-source --statistics`
```
./avogadro-ugm2018/commands/etkdg.py:41:8: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
    if opts['ff'] is 'UFF':
       ^
./avogadro-ugm2018/commands/etkdg.py:43:10: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
    elif opts['ff'] is 'MMFF94':
         ^
2     F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
2
```